### PR TITLE
feat(render): implement rendering pieces as a render-prop

### DIFF
--- a/src/Chessboard/RenderPieces.js
+++ b/src/Chessboard/RenderPieces.js
@@ -56,6 +56,10 @@ export const renderChessPieces = (
     );
   }
 
+  if (typeof pieces[piece] === 'function') {
+    return pieces[piece]({ width: width / 8, height: width / 8, piece });
+  }
+
   return (
     <div data-testid={`${piece}-${currentSquare}`} style={svgStyles}>
       <svg viewBox={`1 1 43 43`}>


### PR DESCRIPTION
provides the ability to pass a render function as a pieces render property, the single argument
provides width, height, and piece.

example:
```
<Chessboard
  pieces={{
    wQ: ({width, height, piece}) => (<div>queen</div>)
  }}
/>
```