### PR TITLE
fix(chessboard): make computer respond on move 1

### DIFF
--- a/src/Chessboard/Board.js
+++ b/src/Chessboard/Board.js
@@ -87,6 +87,7 @@ class Board extends Component {
                         phantomPiece={context.phantomPiece}
                         onPieceClick={context.onPieceClick}
                         wasSquareClicked={context.wasSquareClicked}
+                        allowDrag={context.allowDrag}
                       />
                     ) : null}
 
@@ -102,6 +103,7 @@ class Board extends Component {
                         }
                         pieces={context.pieces}
                         showNotation={context.showNotation}
+                        allowDrag={context.allowDrag}
                       />
                     )}
 

--- a/src/Chessboard/PhantomPiece.js
+++ b/src/Chessboard/PhantomPiece.js
@@ -6,15 +6,17 @@ import { renderChessPiece } from './Piece';
 PhantomPiece.propTypes = {
   width: PropTypes.number,
   phantomPieceValue: PropTypes.string,
-  pieces: PropTypes.object
+  pieces: PropTypes.object,
+  allowDrag: PropTypes.func
 };
 
-function PhantomPiece({ width, pieces, phantomPieceValue }) {
+function PhantomPiece({ width, pieces, phantomPieceValue, allowDrag }) {
   return renderChessPiece({
     width,
     pieces,
     piece: phantomPieceValue,
-    phantomPieceStyles: phantomPieceStyles(width)
+    phantomPieceStyles: phantomPieceStyles(width),
+    allowDrag
   });
 }
 

--- a/src/Chessboard/Piece.js
+++ b/src/Chessboard/Piece.js
@@ -19,6 +19,7 @@ export const renderChessPiece = ({
   isDragging,
   sourceSquare,
   onPieceClick,
+  allowDrag,
   customDragLayerStyles = {},
   phantomPieceStyles = {}
 }) => {
@@ -43,7 +44,9 @@ export const renderChessPiece = ({
           targetSquare,
           sourceSquare,
           getSquareCoordinates,
-          getTranslation
+          getTranslation,
+          piece,
+          allowDrag
         }),
         ...phantomPieceStyles,
         ...customDragLayerStyles
@@ -79,7 +82,8 @@ class Piece extends Component {
     waitForTransition: PropTypes.bool,
     setTouchState: PropTypes.func,
     onPieceClick: PropTypes.func,
-    wasSquareClicked: PropTypes.func
+    wasSquareClicked: PropTypes.func,
+    allowDrag: PropTypes.func
   };
 
   shouldComponentUpdate(nextProps) {
@@ -125,7 +129,8 @@ class Piece extends Component {
       connectDragSource,
       sourceSquare,
       dropTarget,
-      onPieceClick
+      onPieceClick,
+      allowDrag
     } = this.props;
 
     return connectDragSource(
@@ -141,7 +146,8 @@ class Piece extends Component {
         isDragging,
         sourceSquare,
         dropTarget,
-        onPieceClick
+        onPieceClick,
+        allowDrag
       })
     );
   }
@@ -149,7 +155,10 @@ class Piece extends Component {
 
 const pieceSource = {
   canDrag(props) {
-    return props.draggable;
+    return (
+      props.draggable &&
+      props.allowDrag({ piece: props.piece, sourceSquare: props.square })
+    );
   },
   beginDrag(props) {
     return {
@@ -253,7 +262,9 @@ const pieceStyles = ({
   targetSquare,
   sourceSquare,
   getSquareCoordinates,
-  getTranslation
+  getTranslation,
+  piece,
+  allowDrag
 }) => ({
   opacity: isDragging ? 0 : 1,
   transform: getTranslation({
@@ -265,5 +276,9 @@ const pieceStyles = ({
   }),
   transition: `transform ${transitionDuration}ms`,
   zIndex: 5,
-  cursor: isDragging ? '-webkit-grabbing' : '-webkit-grab'
+  cursor: isDragging
+    ? '-webkit-grabbing'
+    : allowDrag({ piece, sourceSquare: square })
+      ? '-webkit-grab'
+      : 'not-allowed'
 });

--- a/src/Chessboard/SparePieces.js
+++ b/src/Chessboard/SparePieces.js
@@ -56,6 +56,7 @@ class SparePieces extends Component {
                     pieces={context.pieces}
                     wasManuallyDropped={context.wasManuallyDropped}
                     onPieceClick={context.onPieceClick}
+                    allowDrag={context.allowDrag}
                   />
                 </div>
               ))}

--- a/src/Chessboard/index.js
+++ b/src/Chessboard/index.js
@@ -163,7 +163,21 @@ class Chessboard extends Component {
      *
      * Signature: function(square: string) => void
      */
-    onSquareRightClick: PropTypes.func
+    onSquareRightClick: PropTypes.func,
+    /**
+     * A function to call when a piece drag is initiated.  Returns true if the piece is draggable,
+     * false if not.
+     *
+     * Signature: function( { piece: string, sourceSquare: string } ) => bool
+     */
+    allowDrag: PropTypes.func,
+    /**
+     * A function to call when a piece drag is initiated.  Returns true if the piece is draggable,
+     * false if not.
+     *
+     * Signature: function( { piece: string, sourceSquare: string } ) => bool
+     */
+    computerMove: PropTypes.bool
   };
 
   static defaultProps = {
@@ -191,13 +205,15 @@ class Chessboard extends Component {
     onDragOverSquare: () => {},
     onSquareClick: () => {},
     onPieceClick: () => {},
-    onSquareRightClick: () => {}
+    onSquareRightClick: () => {},
+    allowDrag: () => true,
+    computerMove: false
   };
 
   static Consumer = ChessboardContext.Consumer;
 
   state = {
-    previousPositionFromProps: null,
+    previousPositionFromProps: getPositionObject(this.props.position),
     currentPosition: getPositionObject(this.props.position),
     sourceSquare: '',
     targetSquare: '',
@@ -207,6 +223,7 @@ class Chessboard extends Component {
     wasPieceTouched: false,
     manualDrop: false,
     squareClicked: false,
+    firstMove: false,
     pieces: { ...defaultPieces, ...this.props.pieces }
   };
 
@@ -269,7 +286,6 @@ class Chessboard extends Component {
 
     // If positionFromProps is a new position then execute, else return null
     if (
-      previousPositionFromProps &&
       !isEqual(positionFromProps, previousPositionFromProps) &&
       !isEqual(positionFromProps, currentPosition)
     ) {

--- a/src/Chessboard/index.js
+++ b/src/Chessboard/index.js
@@ -314,7 +314,10 @@ class Chessboard extends Component {
         return {
           currentPosition: positionFromProps,
           waitForTransition: false,
-          manualDrop: false
+          manualDrop: false,
+          sourceSquare,
+          targetSquare,
+          sourcePiece
         };
       }
 

--- a/src/Demo.js
+++ b/src/Demo.js
@@ -4,13 +4,17 @@ import WithMoveValidation from './integrations/WithMoveValidation';
 import PlayRandomMoveEngine from './integrations/PlayRandomMoveEngine';
 import RandomVsRandomGame from './integrations/RandomVsRandomGame';
 import CustomizedBoard from './integrations/CustomizedBoard';
+import AllowDragFeature from './integrations/AllowDrag';
+import PrestoChangoExample from './integrations/PrestoChango';
 
 class Demo extends Component {
   state = {
     showCustomizedBoard: false,
     showWithMoveValidation: false,
     showRandomVsRandomGame: false,
-    showPlayRandomMoveEngine: false
+    showPlayRandomMoveEngine: false,
+    showAllowDragFeature: false,
+    showPrestoChango: false
   };
   render() {
     return (
@@ -22,7 +26,9 @@ class Demo extends Component {
                 showCustomizedBoard: true,
                 showWithMoveValidation: false,
                 showRandomVsRandomGame: false,
-                showPlayRandomMoveEngine: false
+                showPlayRandomMoveEngine: false,
+                showAllowDragFeature: false,
+                showPrestoChango: false
               })
             }
             style={{ ...buttonStyle, ...{ backgroundColor: 'orange' } }}
@@ -35,7 +41,9 @@ class Demo extends Component {
                 showCustomizedBoard: false,
                 showWithMoveValidation: true,
                 showRandomVsRandomGame: false,
-                showPlayRandomMoveEngine: false
+                showPlayRandomMoveEngine: false,
+                showAllowDragFeature: false,
+                showPrestoChango: false
               })
             }
             style={{
@@ -51,7 +59,9 @@ class Demo extends Component {
                 showCustomizedBoard: false,
                 showWithMoveValidation: false,
                 showRandomVsRandomGame: true,
-                showPlayRandomMoveEngine: false
+                showPlayRandomMoveEngine: false,
+                showAllowDragFeature: false,
+                showPrestoChango: false
               })
             }
             style={{ ...buttonStyle, ...{ backgroundColor: 'gold' } }}
@@ -64,12 +74,47 @@ class Demo extends Component {
                 showCustomizedBoard: false,
                 showWithMoveValidation: false,
                 showRandomVsRandomGame: false,
-                showPlayRandomMoveEngine: true
+                showPlayRandomMoveEngine: true,
+                showAllowDragFeature: false,
+                showPrestoChango: false
               })
             }
             style={{ ...buttonStyle, ...{ backgroundColor: 'silver' } }}
           >
             Play a Random Move Engine
+          </button>
+          <button
+            onClick={() =>
+              this.setState({
+                showCustomizedBoard: false,
+                showWithMoveValidation: false,
+                showRandomVsRandomGame: false,
+                showPlayRandomMoveEngine: false,
+                showAllowDragFeature: true,
+                showPrestoChango: false
+              })
+            }
+            style={{ ...buttonStyle, ...{ backgroundColor: 'aqua' } }}
+          >
+            Conditionally Disable Drag
+          </button>
+          <button
+            onClick={() =>
+              this.setState({
+                showCustomizedBoard: false,
+                showWithMoveValidation: false,
+                showRandomVsRandomGame: false,
+                showPlayRandomMoveEngine: false,
+                showAllowDragFeature: false,
+                showPrestoChango: true
+              })
+            }
+            style={{
+              ...buttonStyle,
+              ...{ backgroundColor: 'brown', color: 'white' }
+            }}
+          >
+            Presto Chango
           </button>
         </div>
         <div style={boardsContainer}>
@@ -77,6 +122,8 @@ class Demo extends Component {
           {this.state.showWithMoveValidation && <WithMoveValidation />}
           {this.state.showRandomVsRandomGame && <RandomVsRandomGame />}
           {this.state.showPlayRandomMoveEngine && <PlayRandomMoveEngine />}
+          {this.state.showAllowDragFeature && <AllowDragFeature />}
+          {this.state.showPrestoChango && <PrestoChangoExample />}
         </div>
       </div>
     );

--- a/src/integrations/AllowDrag.js
+++ b/src/integrations/AllowDrag.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import Chessboard from '../Chessboard';
+
+/* eslint react/display-name: 0 */
+/* eslint react/prop-types: 0 */
+
+class AllowDrag extends Component {
+  static propTypes = { children: PropTypes.func };
+
+  allowDrag = ({ piece }) => {
+    if (piece === 'wB' || piece === 'spare-wB') {
+      return false;
+    }
+    return true;
+  };
+  render() {
+    return this.props.children({ allowDrag: this.allowDrag });
+  }
+}
+
+export default function AllowDragFeature() {
+  return (
+    <div>
+      <AllowDrag>
+        {({ allowDrag }) => (
+          <Chessboard
+            id="allowDrag"
+            orientation="black"
+            calcWidth={({ screenWidth }) => (screenWidth < 500 ? 350 : 480)}
+            position="start"
+            boardStyle={{
+              borderRadius: '5px',
+              boxShadow: `0 5px 15px rgba(0, 0, 0, 0.5)`
+            }}
+            dropOffBoard="trash"
+            sparePieces={true}
+            allowDrag={allowDrag}
+            draggable={true}
+          />
+        )}
+      </AllowDrag>
+    </div>
+  );
+}

--- a/src/integrations/PrestoChango.js
+++ b/src/integrations/PrestoChango.js
@@ -1,41 +1,41 @@
 import React, { Component } from 'react'; // eslint-disable-line no-unused-vars
 import PropTypes from 'prop-types';
-import Chess from 'chess.js';
 
 import Chessboard from '../Chessboard';
 
-class RandomVsRandom extends Component {
+class PrestoChango extends Component {
   static propTypes = { children: PropTypes.func };
 
   state = { fen: 'start' };
 
   componentDidMount() {
-    this.game = new Chess();
-    setTimeout(() => this.makeRandomMove(), 1000);
+    window.setTimeout(this.timer1);
+    window.setTimeout(this.timer2);
+    window.setTimeout(this.timer3);
   }
 
   componentWillUnmount() {
-    window.clearTimeout(this.timer());
+    window.clearTimeout(this.timer1);
+    window.clearTimeout(this.timer2);
+    window.clearTimeout(this.timer3);
   }
 
-  timer = () => window.setTimeout(this.makeRandomMove, 1000);
+  timer1 = () => window.setTimeout(this.onTimer1, 3000);
+  timer2 = () => window.setTimeout(this.onTimer2, 6000);
+  timer3 = () => window.setTimeout(this.onTimer3, 9000);
 
-  makeRandomMove = () => {
-    let possibleMoves = this.game.moves();
+  onTimer1 = () => {
+    this.setState({
+      fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 1 1'
+    });
+  };
 
-    // exit if the game is over
-    if (
-      this.game.game_over() === true ||
-      this.game.in_draw() === true ||
-      possibleMoves.length === 0
-    )
-      return;
+  onTimer2 = () => {
+    this.setState({ fen: '4K1k1/4P3/8/8/8/8/r7/1R6 w - - 0 1' });
+  };
 
-    let randomIndex = Math.floor(Math.random() * possibleMoves.length);
-    this.game.move(possibleMoves[randomIndex]);
-    this.setState({ fen: this.game.fen() });
-
-    this.timer();
+  onTimer3 = () => {
+    this.setState({ fen: '4K1k1/4P3/8/8/8/8/r7/6R1 b - - 1 1' });
   };
 
   render() {
@@ -46,14 +46,14 @@ class RandomVsRandom extends Component {
 
 /* eslint react/display-name: 0 */
 /* eslint react/prop-types: 0 */
-export default function RandomVsRandomGame() {
+export default function PrestoChangoExample() {
   return (
     <div>
-      <RandomVsRandom>
+      <PrestoChango>
         {({ position }) => (
           <Chessboard
             calcWidth={({ screenWidth }) => (screenWidth < 500 ? 350 : 480)}
-            id="random"
+            id="presto"
             position={position}
             transitionDuration={300}
             boardStyle={{
@@ -62,7 +62,7 @@ export default function RandomVsRandomGame() {
             }}
           />
         )}
-      </RandomVsRandom>
+      </PrestoChango>
     </div>
   );
 }


### PR DESCRIPTION
@furrykef

* Shows 'not-allowed' cursor for no-drag pieces
* Addresses problem shown in PrestoChango demo

Take a look at Demo.js with PrestoChango added

I also tested the changes by playing the Stockfish engine and the moves are being played out in the correct order as far as I can tell