### PR TITLE
feat(chessboard): add data attributes for board and squares

### DIFF
--- a/src/Chessboard/Board.js
+++ b/src/Chessboard/Board.js
@@ -41,6 +41,7 @@ class Board extends Component {
               width={context.width}
               boardStyle={context.boardStyle}
               orientation={context.orientation}
+              boardId={context.id}
             >
               {({ square, squareColor, col, row, alpha }) => {
                 return (

--- a/src/Chessboard/Row.js
+++ b/src/Chessboard/Row.js
@@ -8,11 +8,12 @@ class Row extends Component {
     width: PropTypes.number,
     orientation: PropTypes.string,
     boardStyle: PropTypes.object,
-    children: PropTypes.func
+    children: PropTypes.func,
+    boardId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   };
 
   render() {
-    const { width, boardStyle, orientation, children } = this.props;
+    const { width, boardStyle, orientation, children, boardId } = this.props;
     let alpha = COLUMNS;
     let row = 8;
     let squareColor = 'white';
@@ -20,7 +21,10 @@ class Row extends Component {
     if (orientation === 'black') row = 1;
 
     return (
-      <div style={{ ...boardStyles(width), ...boardStyle }}>
+      <div
+        style={{ ...boardStyles(width), ...boardStyle }}
+        data-boardid={boardId}
+      >
         {[...Array(8)].map((_, r) => {
           row = orientation === 'black' ? row + 1 : row - 1;
 

--- a/src/Chessboard/Square.js
+++ b/src/Chessboard/Square.js
@@ -77,6 +77,7 @@ class Square extends Component {
     return connectDropTarget(
       <div
         data-testid={`${squareColor}-square`}
+        data-squareid={square}
         ref={ref => (this[square] = ref)}
         style={defaultSquareStyle(this.props)}
         onMouseOver={() => onMouseOverSquare(square)}


### PR DESCRIPTION
Add data attributes for board and squares for easier selection and styling. Useful for adding
certain styles or annotations to squares based on moves, for instance from an analysis engine.