### PR TITLE
add globalObject to webpack prod build for ability to build in node

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -14,7 +14,8 @@ module.exports = merge(common, {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].min.js',
     library: 'chessboardjsx',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   devtool: 'source-map',
   plugins: [


### PR DESCRIPTION
I was trying to use chessboardjsx in a project with server side rendering. Since some of it accesses the window object it was breaking my webpack server build since there is no window object on the server.

I came across this info that shows how to resolve this:
https://webpack.js.org/configuration/output/#outputglobalobject

When testing on my local build this seems to resolve the issue.