### PR TITLE
fix(chessboard): fix black queen and rook svg

### DIFF
--- a/src/Chessboard/svg/chesspieces/standard.js
+++ b/src/Chessboard/svg/chesspieces/standard.js
@@ -359,7 +359,7 @@ export default {
       <g
         style={{
           opacity: '1',
-          fill: '000000',
+          fill: '#000000',
           fillOpacity: '1',
           fillRule: 'evenodd',
           stroke: '#000000',
@@ -571,7 +571,7 @@ export default {
       <g
         style={{
           opacity: '1',
-          fill: '000000',
+          fill: '#000000',
           fillOpacity: '1',
           fillRule: 'evenodd',
           stroke: '#000000',


### PR DESCRIPTION
Although this repo is unmaintained, this fix is for the issue where black queen and rooks could become transparent when capturing or being rendered. Putting up this PR in case someone else needs this and finds it useful.

Added missing # sign in svg fill color values for the black queen and rook.

https://github.com/willb335/chessboardjsx/issues/71